### PR TITLE
Update OverlayLabel.tsx, disable pointer events

### DIFF
--- a/src/components/OverlayLabel.tsx
+++ b/src/components/OverlayLabel.tsx
@@ -32,7 +32,7 @@ const OverlayLabel = ({
   });
 
   return (
-    <Animated.View style={[StyleSheet.absoluteFillObject, animatedStyle]}>
+    <Animated.View style={[StyleSheet.absoluteFillObject, animatedStyle]} pointerEvents="none">
       <Component />
     </Animated.View>
   );


### PR DESCRIPTION
when OverlayLabelXXX exists, it block TouchableXXX components on the card content. Adding this fix to help with the issue.
