### PR TITLE
Add persisted swipe session restore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The `cardIndex` parameter passed to swipe callbacks represents the card's positi
 | data                       | array                    | Array of data objects used to render the cards.                                                                                                                                    | Yes      |                                |
 | renderCard                 | func(cardData,cardIndex) | Function that renders a card based on the provided data and index.                                                                                                                 | Yes      |                                |
 | initialIndex               | number                   | Initial card index to display when the component first mounts (updates after mount are ignored). Value is clamped to [0, data.length - 1].                                         | No       | 0                              |
+| restoredSwipes             | array                    | Previously swiped card indexes and directions to restore on mount. The continuous restored sequence before `initialIndex` is positioned offscreen without firing swipe callbacks, so `swipeBack()` can rewind through it. | No       |                                |
 | prerenderItems             | number                   | Number of cards to prerender ahead of the active card for better performance. Defaults to `Math.max(data.length - 1, 1)` which ensures optimal rendering for different data sizes. | No       | `Math.max(data.length - 1, 1)` |
 | cardStyle                  | object                   | CSS style properties applied to each card. These can be applied inline.                                                                                                            |          |                                |
 | flippedCardStyle           | object                   | CSS style properties for the back of the card.                                                                                                                                     |          |                                |
@@ -133,6 +134,28 @@ The `cardIndex` parameter passed to swipe callbacks represents the card's positi
 | swipeTop    | callback | Animates the card to fling to the top and calls onSwipeTop       |
 | swipeBottom | callback | Animates the card to fling to the bottom and calls onSwipeBottom |
 | flipCard    | callback | Flips the card to show the back content                          |
+
+## Restoring a swipe session
+
+Use `initialIndex` for the active card and `restoredSwipes` for the cards that were already swiped before the component mounted. Each restored swipe uses the original data index and one of the generic directions: `'left'`, `'right'`, `'top'`, or `'bottom'`. `swipeBack()` can rewind through the continuous restored sequence immediately before `initialIndex`.
+
+`restoredSwipes` is intended to seed the swiper when it mounts, like `initialIndex`. Live controlled updates to `restoredSwipes` after mount are not supported. Load any persisted swipe choices before rendering the swiper, pass the matching `initialIndex` and continuous `restoredSwipes` sequence, then let the swiper manage runtime swipes and `swipeBack()` internally. To apply a different restored session, remount the swiper with the new restore props.
+
+Restoration is silent: `onSwipeLeft`, `onSwipeRight`, `onSwipeTop`, and `onSwipeBottom` are not called for restored entries. When you call `swipeBack()`, restored cards animate back with the same swipe-back spring configuration used for cards swiped during the current runtime session.
+
+```tsx
+<Swiper
+  ref={ref}
+  data={data}
+  initialIndex={3}
+  restoredSwipes={[
+    { index: 0, direction: 'right' },
+    { index: 1, direction: 'left' },
+    { index: 2, direction: 'top' },
+  ]}
+  renderCard={(item) => <Card item={item} />}
+/>
+```
 
 ## Swipe Animation Spring Configs (Animation Speed)
 
@@ -458,6 +481,13 @@ type SwiperCardRefType =
     }
   | undefined;
 
+type SwiperSwipeDirection = 'left' | 'right' | 'top' | 'bottom';
+
+type SwiperRestoredSwipe = {
+  index: number;
+  direction: SwiperSwipeDirection;
+};
+
 type SwiperOptions<T> = {
   /*
    * Card data and render function
@@ -465,6 +495,7 @@ type SwiperOptions<T> = {
   data: T[];
   renderCard: (item: T, index: number) => JSX.Element;
   initialIndex?: number;
+  restoredSwipes?: SwiperRestoredSwipe[];
   prerenderItems?: number;
   cardStyle?: StyleProp<ViewStyle>;
   flippedCardStyle?: StyleProp<ViewStyle>;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -102,6 +102,12 @@ const App = () => {
         <Swiper
           ref={ref}
           data={IMAGES}
+          initialIndex={3}
+          restoredSwipes={[
+            { index: 0, direction: 'right' },
+            { index: 1, direction: 'left' },
+            { index: 2, direction: 'top' },
+          ]}
           cardStyle={styles.cardStyle}
           overlayLabelContainerStyle={styles.overlayLabelContainerStyle}
           renderCard={renderCard}

--- a/src/Swiper.tsx
+++ b/src/Swiper.tsx
@@ -1,15 +1,17 @@
-import React, { useImperativeHandle, type ForwardedRef } from 'react';
+import React, { useImperativeHandle, useMemo, type ForwardedRef } from 'react';
 import { useAnimatedReaction } from 'react-native-reanimated';
 import { Dimensions } from 'react-native';
 import type {
   SwiperCardRefType,
   SwiperOptions,
   SwiperCardOptions,
+  SwiperSwipeDirection,
 } from 'rn-swiper-list';
 import { scheduleOnRN } from 'react-native-worklets';
 
 import useSwipeControls from './hooks/useSwipeControls';
 import SwiperCard from './SwiperCard';
+import type { SwiperCardInternalRefType } from './internalTypes';
 import type { SpringConfig } from 'react-native-reanimated/lib/typescript/animation/spring';
 
 const { width: windowWidth, height: windowHeight } = Dimensions.get('screen');
@@ -73,6 +75,7 @@ const Swiper = <T,>(
     flipDuration = 500,
     overlayLabelContainerStyle,
     initialIndex = 0,
+    restoredSwipes,
   }: SwiperOptions<T>,
   ref: ForwardedRef<SwiperCardRefType>
 ) => {
@@ -82,7 +85,34 @@ const Swiper = <T,>(
     Math.min(initialIndex, data.length - 1)
   );
 
-  // Calculate prerenderItems based on data length from initialIndex
+  const restoredSwipeDirections = useMemo(() => {
+    const directions = new Map<number, SwiperSwipeDirection>();
+
+    restoredSwipes?.forEach(({ index, direction: swipeDirection }) => {
+      if (
+        Number.isInteger(index) &&
+        index >= 0 &&
+        index < clampedInitialIndex &&
+        index < data.length
+      ) {
+        directions.set(index, swipeDirection);
+      }
+    });
+
+    return directions;
+  }, [restoredSwipes, clampedInitialIndex, data.length]);
+
+  const firstRenderedIndex = useMemo(() => {
+    let restoredIndex = clampedInitialIndex - 1;
+
+    while (restoredIndex >= 0 && restoredSwipeDirections.has(restoredIndex)) {
+      restoredIndex--;
+    }
+
+    return restoredIndex + 1;
+  }, [restoredSwipeDirections, clampedInitialIndex]);
+
+  // Calculate prerenderItems based on data length from active index
   const adjustedPrerenderItems = Math.min(
     prerenderItems,
     Math.max(data.length - clampedInitialIndex - 1, 1)
@@ -97,7 +127,7 @@ const Swiper = <T,>(
     swipeTop,
     swipeBottom,
     flipCard,
-  } = useSwipeControls(data, loop, clampedInitialIndex);
+  } = useSwipeControls(data, loop, clampedInitialIndex, firstRenderedIndex);
 
   useImperativeHandle(ref, () => {
     return {
@@ -137,15 +167,15 @@ const Swiper = <T,>(
 
   const Card = SwiperCard as unknown as React.ComponentType<
     React.PropsWithChildren<SwiperCardOptions<T>> & {
-      ref?: React.Ref<SwiperCardRefType>;
+      ref?: React.Ref<SwiperCardInternalRefType>;
     }
   >;
 
   return data
-    .slice(clampedInitialIndex) // Only slice for rendering, not for processing
+    .slice(firstRenderedIndex) // Only slice for rendering, not for processing
     .map((item, index) => {
       // Calculate the actual index in the original data array
-      const actualIndex = index + clampedInitialIndex;
+      const actualIndex = index + firstRenderedIndex;
       return (
         <Card
           key={keyExtractor ? keyExtractor(item, actualIndex) : actualIndex}
@@ -214,6 +244,7 @@ const Swiper = <T,>(
           direction={direction}
           flipDuration={flipDuration}
           overlayLabelContainerStyle={overlayLabelContainerStyle}
+          restoredSwipeDirection={restoredSwipeDirections.get(actualIndex)}
         >
           {renderCard(item, actualIndex)}
         </Card>

--- a/src/SwiperCard/index.tsx
+++ b/src/SwiperCard/index.tsx
@@ -17,14 +17,45 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import type { SwiperCardOptions, SwiperCardRefType } from 'rn-swiper-list';
+import type { SwiperCardOptions, SwiperSwipeDirection } from 'rn-swiper-list';
 import { scheduleOnRN, scheduleOnUI } from 'react-native-worklets';
 
 import OverlayLabel from './OverlayLabel';
+import type { SwiperCardInternalRefType } from '../internalTypes';
+
+const getRestoredTranslateX = (
+  direction: SwiperSwipeDirection | undefined,
+  maxCardTranslation: number
+) => {
+  if (direction === 'right') {
+    return maxCardTranslation;
+  }
+
+  if (direction === 'left') {
+    return -maxCardTranslation;
+  }
+
+  return 0;
+};
+
+const getRestoredTranslateY = (
+  direction: SwiperSwipeDirection | undefined,
+  maxCardTranslationY: number
+) => {
+  if (direction === 'bottom') {
+    return maxCardTranslationY;
+  }
+
+  if (direction === 'top') {
+    return -maxCardTranslationY;
+  }
+
+  return 0;
+};
 
 const SwipeableCard = forwardRef(function SwipeableCard<T>(
   props: PropsWithChildren<SwiperCardOptions<T>>,
-  ref: React.ForwardedRef<SwiperCardRefType>
+  ref: React.ForwardedRef<SwiperCardInternalRefType>
 ) {
   const {
     index,
@@ -74,9 +105,17 @@ const SwipeableCard = forwardRef(function SwipeableCard<T>(
     flipDuration = 2500,
     overlayLabelContainerStyle,
     swipeVelocityThreshold,
+    restoredSwipeDirection,
   } = props;
-  const translateX = useSharedValue(0);
-  const translateY = useSharedValue(0);
+  const { width, height } = useWindowDimensions();
+  const maxCardTranslation = width * 1.5;
+  const maxCardTranslationY = height * 1.5;
+  const translateX = useSharedValue(
+    getRestoredTranslateX(restoredSwipeDirection, maxCardTranslation)
+  );
+  const translateY = useSharedValue(
+    getRestoredTranslateY(restoredSwipeDirection, maxCardTranslationY)
+  );
   const isFlipped = useSharedValue(false);
   // Check if FlippedContent is defined and not null
   const hasFlippedContent =
@@ -86,81 +125,97 @@ const SwipeableCard = forwardRef(function SwipeableCard<T>(
   // These will be updated in gesture handlers
   const nextActiveIndex = useSharedValue(0);
 
-  const { width, height } = useWindowDimensions();
-  const maxCardTranslation = width * 1.5;
-  const maxCardTranslationY = height * 1.5;
-
-  const swipeRight = useCallback(() => {
-    onSwipeRight?.(index);
-    scheduleOnUI(() => {
-      translateX.value = withSpring(maxCardTranslation, {
-        ...swipeRightSpringConfig,
-        reduceMotion: ReduceMotion.Never,
+  const swipeRight = useCallback(
+    (shouldUpdateActiveIndex = true) => {
+      onSwipeRight?.(index);
+      scheduleOnUI(() => {
+        translateX.value = withSpring(maxCardTranslation, {
+          ...swipeRightSpringConfig,
+          reduceMotion: ReduceMotion.Never,
+        });
+        if (shouldUpdateActiveIndex) {
+          activeIndex.value++;
+        }
       });
-      activeIndex.value++;
-    });
-  }, [
-    index,
-    activeIndex,
-    maxCardTranslation,
-    onSwipeRight,
-    translateX,
-    swipeRightSpringConfig,
-  ]);
+    },
+    [
+      index,
+      activeIndex,
+      maxCardTranslation,
+      onSwipeRight,
+      translateX,
+      swipeRightSpringConfig,
+    ]
+  );
 
-  const swipeLeft = useCallback(() => {
-    onSwipeLeft?.(index);
-    scheduleOnUI(() => {
-      translateX.value = withSpring(-maxCardTranslation, {
-        ...swipeLeftSpringConfig,
-        reduceMotion: ReduceMotion.Never,
+  const swipeLeft = useCallback(
+    (shouldUpdateActiveIndex = true) => {
+      onSwipeLeft?.(index);
+      scheduleOnUI(() => {
+        translateX.value = withSpring(-maxCardTranslation, {
+          ...swipeLeftSpringConfig,
+          reduceMotion: ReduceMotion.Never,
+        });
+        if (shouldUpdateActiveIndex) {
+          activeIndex.value++;
+        }
       });
-      activeIndex.value++;
-    });
-  }, [
-    index,
-    activeIndex,
-    maxCardTranslation,
-    onSwipeLeft,
-    translateX,
-    swipeLeftSpringConfig,
-  ]);
+    },
+    [
+      index,
+      activeIndex,
+      maxCardTranslation,
+      onSwipeLeft,
+      translateX,
+      swipeLeftSpringConfig,
+    ]
+  );
 
-  const swipeTop = useCallback(() => {
-    onSwipeTop?.(index);
-    scheduleOnUI(() => {
-      translateY.value = withSpring(-maxCardTranslationY, {
-        ...swipeTopSpringConfig,
-        reduceMotion: ReduceMotion.Never,
+  const swipeTop = useCallback(
+    (shouldUpdateActiveIndex = true) => {
+      onSwipeTop?.(index);
+      scheduleOnUI(() => {
+        translateY.value = withSpring(-maxCardTranslationY, {
+          ...swipeTopSpringConfig,
+          reduceMotion: ReduceMotion.Never,
+        });
+        if (shouldUpdateActiveIndex) {
+          activeIndex.value++;
+        }
       });
-      activeIndex.value++;
-    });
-  }, [
-    index,
-    activeIndex,
-    maxCardTranslationY,
-    onSwipeTop,
-    translateY,
-    swipeTopSpringConfig,
-  ]);
+    },
+    [
+      index,
+      activeIndex,
+      maxCardTranslationY,
+      onSwipeTop,
+      translateY,
+      swipeTopSpringConfig,
+    ]
+  );
 
-  const swipeBottom = useCallback(() => {
-    onSwipeBottom?.(index);
-    scheduleOnUI(() => {
-      translateY.value = withSpring(maxCardTranslationY, {
-        ...swipeBottomSpringConfig,
-        reduceMotion: ReduceMotion.Never,
+  const swipeBottom = useCallback(
+    (shouldUpdateActiveIndex = true) => {
+      onSwipeBottom?.(index);
+      scheduleOnUI(() => {
+        translateY.value = withSpring(maxCardTranslationY, {
+          ...swipeBottomSpringConfig,
+          reduceMotion: ReduceMotion.Never,
+        });
+        if (shouldUpdateActiveIndex) {
+          activeIndex.value++;
+        }
       });
-      activeIndex.value++;
-    });
-  }, [
-    index,
-    activeIndex,
-    maxCardTranslationY,
-    onSwipeBottom,
-    translateY,
-    swipeBottomSpringConfig,
-  ]);
+    },
+    [
+      index,
+      activeIndex,
+      maxCardTranslationY,
+      onSwipeBottom,
+      translateY,
+      swipeBottomSpringConfig,
+    ]
+  );
 
   const swipeBack = useCallback(() => {
     scheduleOnUI(() => {
@@ -177,6 +232,38 @@ const SwipeableCard = forwardRef(function SwipeableCard<T>(
     });
   }, [translateX, translateY, swipeBackXSpringConfig, swipeBackYSpringConfig]);
 
+  const resetAfterLoop = useCallback(() => {
+    const restoredTranslateX = getRestoredTranslateX(
+      restoredSwipeDirection,
+      maxCardTranslation
+    );
+    const restoredTranslateY = getRestoredTranslateY(
+      restoredSwipeDirection,
+      maxCardTranslationY
+    );
+
+    scheduleOnUI(() => {
+      cancelAnimation(translateX);
+      cancelAnimation(translateY);
+      translateX.value = withSpring(restoredTranslateX, {
+        ...swipeBackXSpringConfig,
+        reduceMotion: ReduceMotion.Never,
+      });
+      translateY.value = withSpring(restoredTranslateY, {
+        ...swipeBackYSpringConfig,
+        reduceMotion: ReduceMotion.Never,
+      });
+    });
+  }, [
+    restoredSwipeDirection,
+    maxCardTranslation,
+    maxCardTranslationY,
+    translateX,
+    translateY,
+    swipeBackXSpringConfig,
+    swipeBackYSpringConfig,
+  ]);
+
   const flipCard = useCallback(() => {
     if (hasFlippedContent) {
       isFlipped.value = !isFlipped.value;
@@ -192,8 +279,17 @@ const SwipeableCard = forwardRef(function SwipeableCard<T>(
       swipeTop,
       swipeBottom,
       flipCard,
+      resetAfterLoop,
     };
-  }, [swipeLeft, swipeRight, swipeBack, swipeTop, swipeBottom, flipCard]);
+  }, [
+    swipeLeft,
+    swipeRight,
+    swipeBack,
+    swipeTop,
+    swipeBottom,
+    flipCard,
+    resetAfterLoop,
+  ]);
 
   const inputRangeX = React.useMemo(() => {
     return translateXRange ?? [];

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -183,6 +183,61 @@ describe('Animation Timing and Race Condition Prevention', () => {
   });
 });
 
+describe('Imperative swipe index updates', () => {
+  it('should advance active index once for controller-driven swipes', () => {
+    const steps: string[] = [];
+    let activeIndex = 0;
+
+    const mockCardSwipeRight = (shouldUpdateActiveIndex = true) => {
+      steps.push(`card-swipe:${shouldUpdateActiveIndex}`);
+
+      if (shouldUpdateActiveIndex) {
+        activeIndex += 1;
+      }
+    };
+
+    const mockControllerSwipeRight = () => {
+      mockCardSwipeRight(false);
+      activeIndex += 1;
+      steps.push('controller-update');
+    };
+
+    mockControllerSwipeRight();
+
+    expect(activeIndex).toBe(1);
+    expect(steps).toEqual(['card-swipe:false', 'controller-update']);
+  });
+
+  it('should keep gesture-driven card swipes advancing active index', () => {
+    let activeIndex = 0;
+
+    const mockCardSwipeRight = (shouldUpdateActiveIndex = true) => {
+      if (shouldUpdateActiveIndex) {
+        activeIndex += 1;
+      }
+    };
+
+    mockCardSwipeRight();
+
+    expect(activeIndex).toBe(1);
+  });
+
+  it('should use loop reset without centering restored cards', () => {
+    const calls: string[] = [];
+    const refs = [
+      { current: { resetAfterLoop: () => calls.push('restore:0') } },
+      { current: { resetAfterLoop: () => calls.push('restore:1') } },
+      { current: { resetAfterLoop: () => calls.push('center:2') } },
+    ];
+
+    refs.forEach((ref) => {
+      ref.current.resetAfterLoop();
+    });
+
+    expect(calls).toEqual(['restore:0', 'restore:1', 'center:2']);
+  });
+});
+
 describe('Updated PrerenderItems Calculation', () => {
   it('should use new simplified calculation for prerenderItems default', () => {
     // Test the updated default calculation: Math.max(data.length - 1, 1)
@@ -199,5 +254,128 @@ describe('Updated PrerenderItems Calculation', () => {
       const prerenderItems = Math.max(dataLength - 1, 1);
       expect(prerenderItems).toBe(expected);
     });
+  });
+});
+
+describe('Restored swipe session calculations', () => {
+  const getRestoredSwipeDirections = (
+    restoredSwipes: Array<{
+      index: number;
+      direction: 'left' | 'right' | 'top' | 'bottom';
+    }>,
+    clampedInitialIndex: number,
+    dataLength: number
+  ) => {
+    const directions = new Map<number, 'left' | 'right' | 'top' | 'bottom'>();
+
+    restoredSwipes.forEach(({ index, direction }) => {
+      if (
+        Number.isInteger(index) &&
+        index >= 0 &&
+        index < clampedInitialIndex &&
+        index < dataLength
+      ) {
+        directions.set(index, direction);
+      }
+    });
+
+    return directions;
+  };
+
+  const getFirstRenderedIndex = (
+    restoredSwipeDirections: Map<number, 'left' | 'right' | 'top' | 'bottom'>,
+    clampedInitialIndex: number
+  ) => {
+    let restoredIndex = clampedInitialIndex - 1;
+
+    while (restoredIndex >= 0 && restoredSwipeDirections.has(restoredIndex)) {
+      restoredIndex--;
+    }
+
+    return restoredIndex + 1;
+  };
+
+  it('should render from the earliest restored swipe while keeping initialIndex active', () => {
+    const data = ['item1', 'item2', 'item3', 'item4', 'item5'];
+    const initialIndex = 3;
+    const restoredSwipeDirections = getRestoredSwipeDirections(
+      [
+        { index: 0, direction: 'right' },
+        { index: 1, direction: 'left' },
+        { index: 2, direction: 'top' },
+      ],
+      initialIndex,
+      data.length
+    );
+
+    const firstRenderedIndex = getFirstRenderedIndex(
+      restoredSwipeDirections,
+      initialIndex
+    );
+    const renderedData = data.slice(firstRenderedIndex);
+
+    expect(firstRenderedIndex).toBe(0);
+    expect(renderedData).toEqual(data);
+  });
+
+  it('should ignore restored swipes for the active card and future cards', () => {
+    const dataLength = 5;
+    const initialIndex = 2;
+    const restoredSwipeDirections = getRestoredSwipeDirections(
+      [
+        { index: 0, direction: 'right' },
+        { index: 2, direction: 'left' },
+        { index: 3, direction: 'bottom' },
+      ],
+      initialIndex,
+      dataLength
+    );
+
+    expect(Array.from(restoredSwipeDirections.entries())).toEqual([
+      [0, 'right'],
+    ]);
+  });
+
+  it('should allow swipeBack down to the earliest restored index', () => {
+    const initialIndex = 3;
+    const restoredSwipeDirections = getRestoredSwipeDirections(
+      [
+        { index: 1, direction: 'left' },
+        { index: 2, direction: 'top' },
+      ],
+      initialIndex,
+      5
+    );
+    const swipeBackStartIndex = getFirstRenderedIndex(
+      restoredSwipeDirections,
+      initialIndex
+    );
+
+    const rewindTargets: number[] = [];
+    let activeIndex = initialIndex;
+
+    while (activeIndex - 1 >= swipeBackStartIndex) {
+      activeIndex -= 1;
+      rewindTargets.push(activeIndex);
+    }
+
+    expect(rewindTargets).toEqual([2, 1]);
+  });
+
+  it('should not rewind through gaps in restored swipe indexes', () => {
+    const initialIndex = 4;
+    const restoredSwipeDirections = getRestoredSwipeDirections(
+      [
+        { index: 0, direction: 'right' },
+        { index: 2, direction: 'left' },
+        { index: 3, direction: 'top' },
+      ],
+      initialIndex,
+      5
+    );
+
+    expect(getFirstRenderedIndex(restoredSwipeDirections, initialIndex)).toBe(
+      2
+    );
   });
 });

--- a/src/hooks/useSwipeControls.ts
+++ b/src/hooks/useSwipeControls.ts
@@ -7,17 +7,23 @@ import {
   type RefObject,
 } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
-import type { SwiperCardRefType } from 'rn-swiper-list';
+
+import type { SwiperCardInternalRefType } from '../internalTypes';
 
 const useSwipeControls = <T>(
   data: T[],
   loop: boolean = false,
-  initialIndex: number = 0
+  initialIndex: number = 0,
+  swipeBackStartIndex: number = initialIndex
 ) => {
   // Validate and clamp initialIndex to valid range
   const clampedInitialIndex = Math.max(
     0,
     Math.min(initialIndex, data.length - 1)
+  );
+  const clampedSwipeBackStartIndex = Math.max(
+    0,
+    Math.min(swipeBackStartIndex, clampedInitialIndex)
   );
   const activeIndex = useSharedValue(clampedInitialIndex);
   const dataLength = useRef(data.length);
@@ -29,10 +35,10 @@ const useSwipeControls = <T>(
   }, [data]);
 
   const refs = useMemo(() => {
-    let cardRefs: RefObject<SwiperCardRefType | null>[] = [];
+    let cardRefs: RefObject<SwiperCardInternalRefType | null>[] = [];
 
     for (let i = 0; i < data.length; i++) {
-      cardRefs.push(createRef<SwiperCardRefType>());
+      cardRefs.push(createRef<SwiperCardInternalRefType>());
     }
     return cardRefs;
   }, [data]);
@@ -43,7 +49,7 @@ const useSwipeControls = <T>(
       // Reset all cards to initial position for loop
       activeIndex.value = clampedInitialIndex;
       refs.forEach((ref) => {
-        ref?.current?.swipeBack();
+        ref?.current?.resetAfterLoop();
       });
     } else {
       activeIndex.value++;
@@ -55,7 +61,7 @@ const useSwipeControls = <T>(
     if (!refs[currentIndex]) {
       return;
     }
-    refs[currentIndex]?.current?.swipeRight();
+    refs[currentIndex]?.current?.swipeRight(false);
     updateActiveIndex();
   }, [refs, updateActiveIndex, activeIndex]);
 
@@ -64,7 +70,7 @@ const useSwipeControls = <T>(
     if (!refs[currentIndex]) {
       return;
     }
-    refs[currentIndex]?.current?.swipeTop();
+    refs[currentIndex]?.current?.swipeTop(false);
     updateActiveIndex();
   }, [refs, updateActiveIndex, activeIndex]);
 
@@ -73,7 +79,7 @@ const useSwipeControls = <T>(
     if (!refs[currentIndex]) {
       return;
     }
-    refs[currentIndex]?.current?.swipeLeft();
+    refs[currentIndex]?.current?.swipeLeft(false);
     updateActiveIndex();
   }, [refs, updateActiveIndex, activeIndex]);
 
@@ -82,7 +88,7 @@ const useSwipeControls = <T>(
     if (!refs[currentIndex]) {
       return;
     }
-    refs[currentIndex]?.current?.swipeBottom();
+    refs[currentIndex]?.current?.swipeBottom(false);
     updateActiveIndex();
   }, [refs, updateActiveIndex, activeIndex]);
 
@@ -99,14 +105,14 @@ const useSwipeControls = <T>(
 
     if (
       !loop &&
-      (previousIndex < clampedInitialIndex || !refs[previousIndex])
+      (previousIndex < clampedSwipeBackStartIndex || !refs[previousIndex])
     ) {
       return;
     }
 
     // Handle looping for swipe back
     const targetIndex =
-      previousIndex < clampedInitialIndex
+      previousIndex < clampedSwipeBackStartIndex
         ? dataLength.current - 1
         : previousIndex;
 
@@ -114,7 +120,7 @@ const useSwipeControls = <T>(
       refs[targetIndex]?.current?.swipeBack();
       activeIndex.value = targetIndex;
     }
-  }, [activeIndex, refs, loop, clampedInitialIndex]);
+  }, [activeIndex, refs, loop, clampedSwipeBackStartIndex]);
 
   return {
     activeIndex,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,13 @@ import type { SpringConfig } from 'react-native-reanimated/lib/typescript/animat
 
 export { default as Swiper } from './Swiper';
 
+export type SwiperSwipeDirection = 'left' | 'right' | 'top' | 'bottom';
+
+export type SwiperRestoredSwipe = {
+  index: number;
+  direction: SwiperSwipeDirection;
+};
+
 export type SwiperCardRefType =
   | {
       swipeRight: () => void;
@@ -28,6 +35,7 @@ export type SwiperOptions<T> = {
   loop?: boolean;
   keyExtractor?: (item: T, index: number) => string | number;
   initialIndex?: number;
+  restoredSwipes?: SwiperRestoredSwipe[];
   //* Event callbacks
   onSwipeLeft?: (cardIndex: number) => void;
   onSwipeRight?: (cardIndex: number) => void;
@@ -123,4 +131,5 @@ export type SwiperCardOptions<T> = {
   direction?: 'x' | 'y';
   flipDuration?: number;
   overlayLabelContainerStyle?: StyleProp<ViewStyle>;
+  restoredSwipeDirection?: SwiperSwipeDirection;
 };

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,0 +1,16 @@
+import type { SwiperCardRefType } from 'rn-swiper-list';
+
+type SwipeMethod = (shouldUpdateActiveIndex?: boolean) => void;
+
+export type SwiperCardInternalRefType =
+  | (Omit<
+      NonNullable<SwiperCardRefType>,
+      'swipeRight' | 'swipeLeft' | 'swipeTop' | 'swipeBottom'
+    > & {
+      swipeRight: SwipeMethod;
+      swipeLeft: SwipeMethod;
+      swipeTop: SwipeMethod;
+      swipeBottom: SwipeMethod;
+      resetAfterLoop: () => void;
+    })
+  | undefined;


### PR DESCRIPTION
## Summary

Adds a non-breaking restore API for apps that persist swipe progress and later remount the swiper. Consumers can pass `initialIndex` for the active card and `restoredSwipes` for the continuous sequence of already-swiped cards before that index. Restored cards are seeded offscreen without firing normal swipe callbacks, so repeated `swipeBack()` can rewind through the restored session.

## What Changed

- Added `restoredSwipes` to `SwiperOptions`.
- Exported `SwiperSwipeDirection` and `SwiperRestoredSwipe` TypeScript types.
- Rendered restored previous cards so their animated state exists after remount.
- Seeded restored card translations based on saved swipe direction.
- Let `swipeBack()` rewind through the continuous restored sequence before `initialIndex`.
- Preserved restored offscreen card positions when a looped swiper resets after the last card.
- Documented `restoredSwipes` as mount-time seed input, similar to `initialIndex`.
- Fixed imperative ref swipes so `swipeLeft()`, `swipeRight()`, `swipeTop()`, and `swipeBottom()` advance the active index only once.
- Added `src/internalTypes.ts` for private ref plumbing without changing the public ref API.
- Updated the example to start at index `3` with three restored swipes, making restored rewind easy to debug with the existing `swipeBack()` button.
- Added focused tests for restore calculations, loop reset behavior, and imperative swipe index advancement.

## Restore Lifecycle

`restoredSwipes` is intended to be provided before the swiper mounts. Apps should load persisted choices first, then render the swiper with:

- `initialIndex` set to the current active card index.
- `restoredSwipes` set to the continuous already-swiped sequence immediately before that index.

After mount, the swiper manages runtime swipes and `swipeBack()` internally. Live controlled updates to `restoredSwipes` are not supported; remount the swiper to apply a different restored session.