### PR TITLE
fix: avoid double index increment in imperative swipes

### DIFF
--- a/src/hooks/useSwipeControls.ts
+++ b/src/hooks/useSwipeControls.ts
@@ -62,8 +62,7 @@ const useSwipeControls = <T>(
       return;
     }
     refs[currentIndex]?.current?.swipeRight(false);
-    updateActiveIndex();
-  }, [refs, updateActiveIndex, activeIndex]);
+  }, [refs, activeIndex]);
 
   const swipeTop = useCallback(() => {
     const currentIndex = Math.floor(activeIndex.value);
@@ -71,8 +70,7 @@ const useSwipeControls = <T>(
       return;
     }
     refs[currentIndex]?.current?.swipeTop(false);
-    updateActiveIndex();
-  }, [refs, updateActiveIndex, activeIndex]);
+  }, [refs, activeIndex]);
 
   const swipeLeft = useCallback(() => {
     const currentIndex = Math.floor(activeIndex.value);
@@ -80,8 +78,7 @@ const useSwipeControls = <T>(
       return;
     }
     refs[currentIndex]?.current?.swipeLeft(false);
-    updateActiveIndex();
-  }, [refs, updateActiveIndex, activeIndex]);
+  }, [refs, activeIndex]);
 
   const swipeBottom = useCallback(() => {
     const currentIndex = Math.floor(activeIndex.value);
@@ -89,8 +86,7 @@ const useSwipeControls = <T>(
       return;
     }
     refs[currentIndex]?.current?.swipeBottom(false);
-    updateActiveIndex();
-  }, [refs, updateActiveIndex, activeIndex]);
+  }, [refs, activeIndex]);
 
   const flipCard = useCallback(() => {
     const currentIndex = Math.floor(activeIndex.value);


### PR DESCRIPTION
Issue: https://github.com/Skipperlla/rn-swiper-list/issues/82

This PR removes the redundant `updateActiveIndex()` call from the imperative swipe helpers in `useSwipeControls`.

## Why
`SwiperCard.swipeRight`, `swipeLeft`, `swipeTop`, and `swipeBottom` already increment `activeIndex`.
Calling `updateActiveIndex()` a second time causes imperative swipes to skip cards.

## What changed
- Removed the duplicate index update from:
  - `swipeRight`
  - `swipeLeft`
  - `swipeTop`
  - `swipeBottom`
- Kept the existing behavior inside `SwiperCard` unchanged

## Result
- Gesture swipes still work as before
- Imperative swipes now advance by one card only
- No card skipping when actions are triggered from external buttons or refs

## Notes
This change is limited to the imperative control path and does not affect the gesture handling logic.